### PR TITLE
Added option to retrieve boolean response from JSON content

### DIFF
--- a/src/main/java/us/monoid/web/JSONResource.java
+++ b/src/main/java/us/monoid/web/JSONResource.java
@@ -34,6 +34,13 @@ public class JSONResource extends AbstractResource {
 		return (JSONArray)json;
 	}
 
+	/**
+	/* Parse and return a boolean value
+	/*
+	public boolean bool() throws IOException, JSONException {
+		return (boolean)unmarshal();
+	}
+
 	/** 
 	 * Parse and return JSON object. Parsing is done only once after which the inputStrem is at EOF.
 	 * @return the JSON object


### PR DESCRIPTION
Hi,

sometimes the content returned is a constant true/false. Since there is no way to set the content type for TextResource I've created the "toBoolean" method on JSONResource that simply casts the unmarshaled object to boolean.

I need this since the service I am integrating with is very strict in the content it accepts and can produce (application/json and nothing else) and returns a true/false value.

Best regards,
Matthias.